### PR TITLE
Fix a misplaced character

### DIFF
--- a/src/aztech_font.h
+++ b/src/aztech_font.h
@@ -1,5 +1,5 @@
-#/* Font data from https://jared.geek.nz/2014/jan/custom-fonts-for-microcontrollers */
-include <avr/pgmspace.h>
+/* Font data from https://jared.geek.nz/2014/jan/custom-fonts-for-microcontrollers */
+#include <avr/pgmspace.h>
 const uint8_t ssd1306xled_fontaztech [] PROGMEM = {
   0x00,0x00,0x00,0x00,0x00,0x00, // 0x20 32  
   0x00,0x2e,0x00,0x00,0x00,0x00, // 0x21 33 !


### PR DESCRIPTION
A citation comment was accidentally pasted in a way that splits an include directive. This issue has been fixed.